### PR TITLE
blog: drop permalinks

### DIFF
--- a/source/_snippets/record_meta.latte
+++ b/source/_snippets/record_meta.latte
@@ -1,2 +1,2 @@
-by <em>{$siteAuthor}</em>, {$post->getDateInFormat('d.m.Y')} -
+by <em>{$siteAuthor}</em>, {$post->getDateInFormat('d.m.Y')}
 {if !isset($post['noComments'])} - <a href="/{$post['relativeUrl']}/#disqus_thread">Comment</a>{/if}<br />

--- a/source/_snippets/record_meta.latte
+++ b/source/_snippets/record_meta.latte
@@ -1,2 +1,2 @@
 by <em>{$siteAuthor}</em>, {$post->getDateInFormat('d.m.Y')} -
-<a href="/{$post['relativeUrl']}/">Permalink</a>{if !isset($post['noComments'])} - <a href="/{$post['relativeUrl']}/#disqus_thread">Comment</a>{/if}<br />
+{if !isset($post['noComments'])} - <a href="/{$post['relativeUrl']}/#disqus_thread">Comment</a>{/if}<br />


### PR DESCRIPTION
They are the same as blog headlines. No need to duplicate those links.